### PR TITLE
Remove IE11 from compatibility list

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,10 +132,12 @@ For EU compliance, consider adding:
 - **Mobile display problems**: Test on actual mobile devices, not just browser resize
 
 ### Browser Compatibility
-The website works on:
-- Chrome, Firefox, Safari, Edge (latest versions)
+The website targets **modern browsers** and is officially supported on:
+- Chrome (latest versions)
+- Firefox (latest versions)
+- Safari (latest versions)
+- Edge (latest versions)
 - Mobile browsers on iOS and Android
-- Internet Explorer 11+ (with some limitations)
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- remove IE11 mention in the Browser Compatibility section
- specify that the site targets modern browsers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684485daa0648325baf4ed7406defef8